### PR TITLE
カメラの反転機能追加

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ const canvasContext = canvas.getContext("2d")!;
 let lastVideoTime = -1;
 let handLandmarkerResult: HandLandmarkerResult;
 let detectedAtLastFrame = false;
+let imageReverse = false;
 startVideo();
 
 
@@ -35,6 +36,7 @@ async function startVideo() {
     },
   });
   video.srcObject = stream;
+  if (imageReverse) video.style.transform = "scaleX(-1)";
   video.addEventListener("loadeddata", predictWebcam);
 }
 
@@ -67,7 +69,7 @@ function drawHandLandmarks(handLandmarkerResult: HandLandmarkerResult) {
       for (const landmark of landmarks) {
         canvasContext.beginPath();
         canvasContext.arc(
-          landmark.x * canvas.width,
+          imageReverse ? (1 - landmark.x) * canvas.width : landmark.x * canvas.width,
           landmark.y * canvas.height,
           5,
           0,


### PR DESCRIPTION
This pull request introduces a feature to optionally reverse the image in the webcam feed and updates the hand landmark drawing logic to accommodate this change. The key changes include adding a new flag `imageReverse`, modifying the video element's style based on this flag, and adjusting the coordinates for drawing hand landmarks accordingly.

### New feature to reverse webcam image:

* [`src/main.ts`](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR25): Introduced a new boolean flag `imageReverse` to control whether the webcam image should be reversed.
* [`src/main.ts`](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR39): Updated the `startVideo` function to apply a horizontal flip to the video element if `imageReverse` is true.

### Adjustments for hand landmark drawing:

* [`src/main.ts`](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL70-R72): Modified the `drawHandLandmarks` function to reverse the x-coordinate of landmarks if `imageReverse` is true.